### PR TITLE
label show property(allow to disable if always displayed)

### DIFF
--- a/SwitchAsset.php
+++ b/SwitchAsset.php
@@ -16,7 +16,7 @@ use yii\web\AssetBundle;
  */
 class SwitchAsset extends AssetBundle
 {
-    public $sourcePath = '@vendor/2amigos/yii2-switch-widget/assets';
+    public $sourcePath = '@vendor/phpffcms/yii2-switch-widget/assets';
 
     public $depends = [
         'yii\bootstrap\BootstrapPluginAsset'

--- a/SwitchBox.php
+++ b/SwitchBox.php
@@ -35,14 +35,20 @@ class SwitchBox extends InputWidget
     /**
      * @var bool whether to display the label inline or not. Defaults to true.
      */
-    public $inlineLabel = true;
+    public $inlineLabel = false;
+
+    /**
+     * @var bool show label with widget checkbox switcher. Default is true.
+     */
+    public $showLabel = true;
 
     /**
      * @inheritdoc
      */
     public function run()
     {
-
+        if(!$this->showLabel)
+            $this->options['label'] = false;
         if ($this->hasModel()) {
             $input = Html::activeCheckbox($this->model, $this->attribute, $this->options);
         } else {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "2amigos/yii2-switch-widget",
+    "name": "phpffcms/yii2-switch-widget",
     "description": "Bootstrap Switch widget for Yii2.",
     "keywords": ["yii", "extension", "widget", "switch"],
     "type": "yii2-extension",


### PR DESCRIPTION
If we build form with pre-defined template with labels and try to use SwitchBox label could be displayed in 2 times:
`
        <?= $form->field($model, 'login_captcha')->widget(SwitchBox::className(),[]) ?>
`
so i suggest add param to disable label view automaticly with widget:
`
        <?= $form->field($model, 'login_captcha')->widget(SwitchBox::className(),[
            'showLabel' => false,
        ]) ?>
`
