### PR TITLE
Update SwitchBox.php

### DIFF
--- a/src/SwitchBox.php
+++ b/src/SwitchBox.php
@@ -43,7 +43,9 @@ class SwitchBox extends InputWidget
      */
     public function run()
     {
-
+        if ($this->inlineLabel == false) {
+            $this->options['label'] = false;
+        }
         if ($this->hasModel()) {
             $input = Html::activeCheckbox($this->model, $this->attribute, $this->options);
         } else {


### PR DESCRIPTION
Now $inlineLabel is checked and if it is set to false the widget won't show the inline label as expected.